### PR TITLE
feat: Add ability to silence warning for missing css chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ If you don't wanna do that, you can dig through your webpack stats and manually 
 ```
 **Or if you already use the [html-webpack-plugin](https://webpack.js.org/plugins/html-webpack-plugin/) as part of your build process, take a look at the [flush-chunks-html](https://github.com/m4r1vs/webpack-flush-chunks-html) plugin for webpack. It identifies all your generated css-chunks and adds them to your html file like shown above during build!**
 
+In development, a warning will be logged if there are any JS bundles dynamically imported which are not associated with a css chunk in __CSS_CHUNKS__.
+This warning can be silenced by setting the CSS chunk path for a module to `no-css-chunk-expected`. For instance:
+
+```html
+<script>
+  window.__CSS_CHUNKS__ = {
+    'base/Page1': '/static/base/Page1.css',
+    'some-module': 'no-css-chunk-expected',
+  }
+</script>
+```
+
 ## Usage with [react-universal-component](https://github.com/faceyspacey/react-universal-component) and [webpack-flush-chunks](https://github.com/faceyspacey/webpack-flush-chunks)
 
 When using `webpack-flush-chunks` you will have to supply the `chunkNames` option, not the `moduleIds` option since this plugin is based on chunk names. Here's an example:
@@ -160,7 +172,7 @@ We use [commitizen](https://github.com/commitizen/cz-cli), so run `npm run cm` t
 
 ## Tests
 
-Reviewing a package's tests are a great way to get familiar with it. It's direct insight into the capabilities of the given package (if the tests are thorough). What's even better is a screenshot of the tests neatly organized and grouped (you know the whole "a picture says a thousand words" thing). 
+Reviewing a package's tests are a great way to get familiar with it. It's direct insight into the capabilities of the given package (if the tests are thorough). What's even better is a screenshot of the tests neatly organized and grouped (you know the whole "a picture says a thousand words" thing).
 
 Below is a screenshot of this module's tests running in [Wallaby](https://wallabyjs.com) *("An Integrated Continuous Testing Tool for JavaScript")* which everyone in the React community should be using. It's fantastic and has taken my entire workflow to the next level. It re-runs your tests on every change along with comprehensive logging, bi-directional linking to your IDE, in-line code coverage indicators, **and even snapshot comparisons + updates for Jest!** I requestsed that feature by the way :). It's basically a substitute for live-coding that inspires you to test along your journey.
 

--- a/importCss.js
+++ b/importCss.js
@@ -1,68 +1,73 @@
 /* eslint-disable */
 
 var ADDED = {};
+var NO_CSS_CHUNK_EXPECTED = 'no-css-chunk-expected';
 
 module.exports = function(chunkName) {
-  var href = getHref(chunkName)
+  var href = getHref(chunkName);
+
+  if (href === NO_CSS_CHUNK_EXPECTED) {
+    return;
+  }
+
   if (!href) {
     if (process.env.NODE_ENV === 'development') {
       if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) {
         console.warn(
           '[DUAL-IMPORT] no css chunks hash found at "window.__CSS_CHUNKS__"'
-        )
-        return
+        );
+      } else {
+        console.warn(
+          '[DUAL-IMPORT] no chunk, ',
+          chunkName,
+          ', found in "window.__CSS_CHUNKS__"'
+        );
       }
-
-      console.warn(
-        '[DUAL-IMPORT] no chunk, ',
-        chunkName,
-        ', found in "window.__CSS_CHUNKS__"'
-      )
     }
 
-    return
+    return;
   }
-  
+
   if (ADDED[href] === true) {
     return Promise.resolve();
   }
   ADDED[href] = true;
 
-  var head = document.getElementsByTagName('head')[0]
-  var link = document.createElement('link')
+  var head = document.getElementsByTagName('head')[0];
+  var link = document.createElement('link');
 
-  link.href = href
-  link.charset = 'utf-8'
-  link.type = 'text/css'
-  link.rel = 'stylesheet'
-  link.timeout = 30000
+  link.href = href;
+  link.charset = 'utf-8';
+  link.type = 'text/css';
+  link.rel = 'stylesheet';
+  link.timeout = 30000;
 
   return new Promise(function(resolve, reject) {
-    var timeout
+    var timeout;
 
     link.onerror = function() {
-      link.onerror = link.onload = null // avoid mem leaks in IE.
-      clearTimeout(timeout)
-      var message = 'could not load css chunk:${chunkName}'
-      reject(new Error(message))
-    }
+      link.onerror = link.onload = null; // avoid mem leaks in IE.
+      clearTimeout(timeout);
+      var message = 'could not load css chunk:${chunkName}';
+      reject(new Error(message));
+    };
 
     // link.onload doesn't work well enough, but this will handle it
     // since images can't load css (this is a popular fix)
-    var img = document.createElement('img')
+    var img = document.createElement('img');
     img.onerror = function() {
-      link.onerror = img.onerror = null // avoid mem leaks in IE.
-      clearTimeout(timeout)
-      resolve()
-    }
+      link.onerror = img.onerror = null; // avoid mem leaks in IE.
+      clearTimeout(timeout);
+      resolve();
+    };
 
-    timeout = setTimeout(link.onerror, link.timeout)
-    head.appendChild(link)
-    img.src = href
-  })
-}
+    timeout = setTimeout(link.onerror, link.timeout);
+    head.appendChild(link);
+    img.src = href;
+  });
+};
 
 function getHref(chunkName) {
-  if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) return null
-  return window.__CSS_CHUNKS__[chunkName]
+  if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) return null;
+  return window.__CSS_CHUNKS__[chunkName];
 }


### PR DESCRIPTION
When pulling in external modules, often there is no css to go along with the async JS chunk that is
dynamically imported. For these cases, there should be a way to silence the warning that is logged
in development about missing CSS chunks.

This is copied from Sean's fork which current has a [dangling commit](https://github.com/seankarson/babel-plugin-dual-import/commit/6a4225f01d99f36116785e933b1012596eb6a4b3) with no associated branch. Yarn seems to barf on finding that commit. 