### PR TITLE
fix error message and log more details

### DIFF
--- a/importCss.js
+++ b/importCss.js
@@ -1,13 +1,13 @@
 /* eslint-disable */
 
-var ADDED = {};
-var NO_CSS_CHUNK_EXPECTED = 'no-css-chunk-expected';
+var ADDED = {}
+var NO_CSS_CHUNK_EXPECTED = 'no-css-chunk-expected'
 
 module.exports = function(chunkName) {
-  var href = getHref(chunkName);
+  var href = getHref(chunkName)
 
   if (href === NO_CSS_CHUNK_EXPECTED) {
-    return;
+    return
   }
 
   if (!href) {
@@ -15,59 +15,72 @@ module.exports = function(chunkName) {
       if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) {
         console.warn(
           '[DUAL-IMPORT] no css chunks hash found at "window.__CSS_CHUNKS__"'
-        );
+        )
       } else {
         console.warn(
           '[DUAL-IMPORT] no chunk, ',
           chunkName,
           ', found in "window.__CSS_CHUNKS__"'
-        );
+        )
       }
     }
 
-    return;
+    return
   }
 
   if (ADDED[href] === true) {
-    return Promise.resolve();
+    return Promise.resolve()
   }
-  ADDED[href] = true;
+  ADDED[href] = true
 
-  var head = document.getElementsByTagName('head')[0];
-  var link = document.createElement('link');
+  var head = document.getElementsByTagName('head')[0]
+  var link = document.createElement('link')
 
-  link.href = href;
-  link.charset = 'utf-8';
-  link.type = 'text/css';
-  link.rel = 'stylesheet';
-  link.timeout = 30000;
+  link.href = href
+  link.charset = 'utf-8'
+  link.type = 'text/css'
+  link.rel = 'stylesheet'
+  link.timeout = 30000
 
   return new Promise(function(resolve, reject) {
-    var timeout;
+    var timeout
+    var linkTimedOut = false
 
-    link.onerror = function() {
-      link.onerror = link.onload = null; // avoid mem leaks in IE.
-      clearTimeout(timeout);
-      var message = 'could not load css chunk:${chunkName}';
-      reject(new Error(message));
-    };
+    link.onerror = function(e) {
+      link.onerror = link.onload = null // avoid mem leaks in IE.
+      clearTimeout(timeout)
+      var message = [
+        'Could not load css chunk:',
+        chunkName,
+        '-',
+        href + '.',
+        'Time on page:',
+        e.timeStamp,
+        'ms.',
+        linkTimedOut ? 'Timed out.' : ''
+      ].join(' ')
+      reject(new Error(message))
+    }
 
     // link.onload doesn't work well enough, but this will handle it
     // since images can't load css (this is a popular fix)
-    var img = document.createElement('img');
+    var img = document.createElement('img')
     img.onerror = function() {
-      link.onerror = img.onerror = null; // avoid mem leaks in IE.
-      clearTimeout(timeout);
-      resolve();
-    };
+      link.onerror = img.onerror = null // avoid mem leaks in IE.
+      clearTimeout(timeout)
+      resolve()
+    }
 
-    timeout = setTimeout(link.onerror, link.timeout);
-    head.appendChild(link);
-    img.src = href;
-  });
-};
+    timeout = setTimeout(function() {
+      linkTimedOut = true
+      link.onerror()
+    }, link.timeout)
+    head.appendChild(link)
+    img.src = href
+  })
+}
 
 function getHref(chunkName) {
-  if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) return null;
-  return window.__CSS_CHUNKS__[chunkName];
+  if (typeof window === 'undefined' || !window.__CSS_CHUNKS__) return null
+  return window.__CSS_CHUNKS__[chunkName]
 }

--- a/importCss.js
+++ b/importCss.js
@@ -57,7 +57,8 @@ module.exports = function(chunkName) {
         'Time on page:',
         e.timeStamp,
         'ms.',
-        linkTimedOut ? 'Timed out.' : ''
+        linkTimedOut ? 'Timed out.' : '',
+        '__CSS_CHUNKS__: ' + JSON.stringify(window.__CSS_CHUNKS__)
       ].join(' ')
       reject(new Error(message))
     }


### PR DESCRIPTION
@sandinmyjoints 

### What/why

We're getting a bunch of `Unhandled Rejection: could not load css chunk:${chunkName}` client-side errors in loggly. I haven't been able to tell what the actual problem is. This error message is a failed attempt to log the `chunkName` that did not load. 

In order to track down the real cause, I added a few more logged items in addition to fixing this bug.

### How to test

Apply this diff to neodarwin and `yarn`.

```diff
diff --git a/package.json b/package.json
index 12a6f062a..8a615eebe 100644
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "array-shuffle": "1.0.1",
     "async": "1.5.2",
-    "babel-plugin-dual-import": "git+ssh://git@github.com/spanishdict/babel-plugin-dual-import.git#e1442ab2d8aea5be9d60ae3160ab9cb35f600651",
+    "babel-plugin-dual-import": "git+ssh://git@github.com/spanishdict/babel-plugin-dual-import.git#3ba63a115131e22338e4ed0ecc12fc71a7b1361c",
     "body-parser": "=1.17.1",
     "cheerio": "=0.17.0",
     "chokidar": "^1.7.0",


```

I blocked a particular async css url in chrome dev tools to trigger the error here. It should log the actual chunk name as well as some additional useful info.

![image](https://user-images.githubusercontent.com/2068437/49592585-85550e80-f93f-11e8-8e92-476d8c004c60.png)


cc @spanishdict/engineering-sd-engage 